### PR TITLE
update memory to success Test cicd stage

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,14 +82,11 @@ Vagrant.configure(2) do |config|
     apt-get install -y git tree wget vim python3-dev python3-pip python3-venv apt-transport-https python3-selenium
     apt-get upgrade python3
     
-    # Install Chromium Driver
-    apt-get install -y chromium-driver
-    
     # Need PostgreSQL development library to compile on arm64
     apt-get install -y libpq-dev
 
     # Install Chromium Driver
-    apt-get install -y chromium-chromedriver
+    apt-get install -y chromium-driver
 
     # Create a Python3 Virtual Environment and Activate it in .profile
     sudo -H -u vagrant sh -c 'python3 -m venv ~/venv'

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
 - name: nyu-promotion-service-sum21
   path: .
   instances: 2
-  memory: 64M
+  memory: 256M
   routes:
   - route: nyu-promotion-service-sum21.us-south.cf.appdomain.cloud
   disk_quota: 1024M


### PR DESCRIPTION
Memory size was not enough to run BDD at IBMCloud, so that add more memory.
Also, remove unnecessary code in Vagrantfile.

After update memory, `Test` stage ran successfully by manual 
Even after updating Vagrantfile, `vagrant up`, `behave` ran successfully on my PC (not M1 mac) and Travis CI.