### PR TITLE
Revert "add prod app in manifest"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,19 +16,3 @@ applications:
   env:
     FLASK_APP : service:app
     FLASK_DEBUG : false
-
-- name: nyu-promotion-service-sum21-prod
-  path: .
-  instances: 2
-  memory: 256M
-  routes:
-  - route: nyu-promotion-service-sum21-prod.us-south.cf.appdomain.cloud
-  disk_quota: 1024M
-  buildpacks:
-  - python_buildpack
-  timeout: 180
-  services:
-  - ElephantSQL
-  env:
-    FLASK_APP : service:app
-    FLASK_DEBUG : false


### PR DESCRIPTION
Reverts nyu-devops-2021-summer-promotions/promotions#136
It does not work stable at IBM cloud, and not it does not work, so we need to keep the other way.